### PR TITLE
[Bug] Small Number Doubled

### DIFF
--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -102,6 +102,17 @@ class SendMessageRequest(BaseModel):
             raise ValueError("Invalid message type")
         return v
 
+    @field_validator("content", mode="before")
+    @classmethod
+    def validate_content_before(cls, v):
+        """Convert content to string if it's a number or other type"""
+        if v is None:
+            return None
+        # Convert numbers and other types to string
+        if not isinstance(v, str):
+            return str(v)
+        return v
+
     @field_validator("content")
     @classmethod
     def validate_content(cls, v: str | None) -> str:


### PR DESCRIPTION
The `mode="before"` validator converts numeric values to strings before validation, which should prevent duplication when numbers like `80` are sent as JSON numbers.

## Summary

The issue was in the `SendMessageRequest` model's `content` field validator. When a numeric value like `80` is sent as a JSON number (not a string), Pydantic's type conversion can cause unexpected behavior.

**The fix:**
- Added a `mode="before"` validator that explicitly converts numeric values (and other non-string types) to strings before the main validation
- This ensures that `80` becomes `"80"` (not `"8080"`)

est by sending a numeric value like `80` as the content; it should be processed as `"80"` without duplication.
