### PR TITLE
Fix nginx validation in CI/CD by separating rate limit zones

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -194,7 +194,9 @@ jobs:
             # Step 2: Validate nginx configuration
             echo "[INFO] Validating nginx configuration"
             docker run --rm \
+              -v "$(pwd)/nginx/rate-limit-zones.conf:/etc/nginx/conf.d/rate-limit-zones.conf:ro" \
               -v "$(pwd)/nginx/yral-ai-chat.conf:/etc/nginx/conf.d/default.conf:ro" \
+              -v "$(pwd)/nginx/nginx.conf.wrapper:/etc/nginx/nginx.conf:ro" \
               -v /etc/letsencrypt:/etc/letsencrypt:ro \
               nginx:alpine nginx -t
             

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -194,7 +194,9 @@ jobs:
             # Step 2: Validate nginx configuration
             echo "[INFO] Validating nginx configuration"
             docker run --rm \
+              -v "$(pwd)/nginx/rate-limit-zones.conf:/etc/nginx/conf.d/rate-limit-zones.conf:ro" \
               -v "$(pwd)/nginx/yral-ai-chat.conf:/etc/nginx/conf.d/default.conf:ro" \
+              -v "$(pwd)/nginx/nginx.conf.wrapper:/etc/nginx/nginx.conf:ro" \
               -v /etc/letsencrypt:/etc/letsencrypt:ro \
               nginx:alpine nginx -t
             

--- a/nginx/VALIDATION_FIX.md
+++ b/nginx/VALIDATION_FIX.md
@@ -1,0 +1,53 @@
+# Nginx Configuration Validation Fix
+
+## Problem
+
+The CI/CD validation fails because `limit_req_zone` directives must be in the `http` context, not in a `server` block. The validation command tests the config file in isolation without the `http` context.
+
+## Solution
+
+The rate limiting zones have been moved to a separate file (`rate-limit-zones.conf`) that should be included in the main `nginx.conf` `http` block.
+
+## For CI/CD Validation
+
+Update the validation command in your CI/CD workflow to use a wrapper nginx.conf:
+
+**Current (failing):**
+```bash
+docker run --rm \
+  -v "$(pwd)/nginx/yral-ai-chat.conf:/etc/nginx/conf.d/default.conf:ro" \
+  -v /etc/letsencrypt:/etc/letsencrypt:ro \
+  nginx:alpine nginx -t
+```
+
+**Updated (working):**
+```bash
+docker run --rm \
+  -v "$(pwd)/nginx/rate-limit-zones.conf:/etc/nginx/conf.d/rate-limit-zones.conf:ro" \
+  -v "$(pwd)/nginx/yral-ai-chat.conf:/etc/nginx/conf.d/default.conf:ro" \
+  -v "$(pwd)/nginx/nginx.conf.wrapper:/etc/nginx/nginx.conf:ro" \
+  -v /etc/letsencrypt:/etc/letsencrypt:ro \
+  nginx:alpine nginx -t
+```
+
+## For Production Deployment
+
+On the server, ensure the main `/etc/nginx/nginx.conf` includes the rate limiting zones in the `http` block:
+
+```nginx
+http {
+    # ... other http-level directives ...
+    
+    # Include rate limiting zones
+    include /etc/nginx/rate-limit-zones.conf;
+    
+    # Include site configurations
+    include /etc/nginx/sites-enabled/*;
+}
+```
+
+And copy the zones file:
+```bash
+sudo cp nginx/rate-limit-zones.conf /etc/nginx/rate-limit-zones.conf
+```
+

--- a/nginx/nginx.conf.wrapper
+++ b/nginx/nginx.conf.wrapper
@@ -1,0 +1,16 @@
+# Temporary nginx.conf wrapper for validation
+# This file wraps the site config with proper http context for validation
+# Used by CI/CD to validate nginx configuration
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Include rate limiting zones (must be in http context)
+    include /etc/nginx/conf.d/rate-limit-zones.conf;
+    
+    # Include the site configuration
+    include /etc/nginx/conf.d/default.conf;
+}
+

--- a/nginx/rate-limit-zones.conf
+++ b/nginx/rate-limit-zones.conf
@@ -1,0 +1,9 @@
+# Rate limiting zones configuration
+# This file should be included in the http context of nginx.conf
+# For site-specific configs, these zones are defined here and referenced in server blocks
+
+# Per-minute limit: 300 requests per minute per IP
+limit_req_zone $binary_remote_addr zone=per_minute:10m rate=300r/m;
+# Per-hour limit: 5000 requests per hour per IP
+limit_req_zone $binary_remote_addr zone=per_hour:10m rate=5000r/h;
+

--- a/nginx/yral-ai-chat.conf
+++ b/nginx/yral-ai-chat.conf
@@ -76,11 +76,9 @@ server {
     proxy_buffers 8 4k;
     proxy_busy_buffers_size 8k;
 
-    # Rate limiting zones
-    # Per-minute limit: 300 requests per minute per IP
-    limit_req_zone $binary_remote_addr zone=per_minute:10m rate=300r/m;
-    # Per-hour limit: 5000 requests per hour per IP
-    limit_req_zone $binary_remote_addr zone=per_hour:10m rate=5000r/h;
+    # Rate limiting zones are defined in nginx/rate-limit-zones.conf
+    # and should be included in the http context of the main nginx.conf
+    # These zones are referenced below using limit_req directives
 
     # Staging environment - route /staging/* to staging container (port 8001)
     # This must come before the root location block to match first


### PR DESCRIPTION
- Move limit_req_zone directives to separate file (must be in http context)
- Create nginx.conf.wrapper for CI/CD validation
- Update GitHub Actions workflows to use wrapper for validation
- Fixes 'limit_req_zone directive is not allowed here' error