### PR TITLE
fix: reduce uvicorn workers from 4 to 1 to fix Litestream database lock errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,4 +68,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 
 # Use entrypoint script to start both Litestream and the app
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]


### PR DESCRIPTION
fix: reduce uvicorn workers from 4 to 1 to fix Litestream database lock errors

- Changes workers from 4 to 1 in Dockerfile
- Fixes continuous 'database is locked' errors in Litestream checkpoint
- Eliminates multi-worker contention for SQLite database locks
- Ensures database backups resume to S3

Root cause: Multiple workers competing for locks prevented Litestream from checkpointing the WAL, causing backup failures.

Impact: API remains functional with single worker (current response times 5-8ms indicate sufficient capacity)