### PR TITLE
tune: increase Litestream sync-interval to 30s to reduce lock errors

### DIFF
--- a/config/litestream.yml
+++ b/config/litestream.yml
@@ -12,8 +12,8 @@ dbs:
         region: ${LITESTREAM_REGION}
         access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
         secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
-        # Sync settings
-        sync-interval: 10s
+        # Sync settings - tuned to reduce lock contention
+        sync-interval: 30s
         # Retention settings
         retention: 24h
         retention-check-interval: 1h


### PR DESCRIPTION
- Increase sync-interval from 10s to 30s in config/litestream.yml
- Reduces checkpoint frequency to minimize lock contention
- Expected to reduce lock errors to 1-2/day or less

Complements worker reduction (4→1) for more stable backups.