### PR TITLE
Lock fixes n optimizations

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     port: int = Field(default=8000, ge=1, le=65535, alias="PORT")
 
     database_path: str = Field(default="data/yral_chat.db", alias="DATABASE_PATH")
-    database_pool_size: int = Field(default=20, ge=1, le=50, alias="DATABASE_POOL_SIZE")
+    database_pool_size: int = Field(default=10, ge=1, le=50, alias="DATABASE_POOL_SIZE")
     database_pool_timeout: float = Field(default=60.0, gt=0, alias="DATABASE_POOL_TIMEOUT")
 
     jwt_secret_key: str = Field(..., alias="JWT_SECRET_KEY")

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -63,8 +63,11 @@ class ConnectionPool:
         await conn.execute("PRAGMA journal_mode = WAL")
         
         # Litestream optimization: Prevent WAL from growing too large
-        await conn.execute("PRAGMA wal_autocheckpoint = 4000")
-        await conn.execute("PRAGMA journal_size_limit = 16777216") # 16MB
+        # Increased to 10000 pages (~40MB) to reduce checkpoint frequency under load
+        await conn.execute("PRAGMA wal_autocheckpoint = 10000")
+        
+        # Increased to 64MB to prevent excessive truncation/checkpoints
+        await conn.execute("PRAGMA journal_size_limit = 67108864")
         
         # Timeout handling
         # We set a high busy_timeout to allow queuing during checkpoints
@@ -74,7 +77,7 @@ class ConnectionPool:
         # Performance tuning
         await conn.execute("PRAGMA synchronous = NORMAL")
         await conn.execute("PRAGMA mmap_size = 268435456")  # 256MB
-        await conn.execute("PRAGMA cache_size = -20000")    # 20MB
+        await conn.execute("PRAGMA cache_size = -64000")    # 64MB (negative value = kb)
         await conn.execute("PRAGMA temp_store = MEMORY")
 
         


### PR DESCRIPTION
# Root Cause Analysis

The production database was experiencing severe lock contention, with `INSERT` queries timing out or taking 6-60 seconds.

* **Symptoms:** `Slow execute` logs for simple `INSERT INTO messages`, request timeouts.
* **Cause:** High write concurrency combined with slow underlying I/O (likely caused by frequent WAL checkpoints and Litestream replication overhead on the storage layer).
* **Mechanism:** The default `wal_autocheckpoint` (4000 pages / 16MB) was triggering too frequently. Checkpointing requires writing modified pages from WAL back to the main DB file. If the storage layer is slow (logs showed ~200ms for WAL segment writes), these checkpoints block writers or consume IOPS, causing the single-writer queue to back up.
* **Compounding Factor:** A connection pool size of 20 allows 20 concurrent threads to attempt writes, overwhelming the SQLite busy handler.

## Changes Applied

Modified `src/db/base.py` to tune SQLite PRAGMA settings for high-throughput WAL mode:

1. **Increased `PRAGMA wal_autocheckpoint` to 10000 (approx 40MB):** Reduces the frequency of checkpoints, allowing more updates to happen in the WAL (sequential writes) before needing to sync to the main DB (random writes).
2. **Increased `PRAGMA journal_size_limit` to 64MB:** Prevents aggressive truncation of the WAL file, which can lock the DB.
3. **Increased `PRAGMA cache_size` to 64MB:** Improves read performance and reduces disk pressure.
4. Decreased database_pool_size to 10