### PR TITLE
BackwardRestore V1 Backward Compatibility: last_message

### DIFF
--- a/src/api/v1/chat.py
+++ b/src/api/v1/chat.py
@@ -189,6 +189,7 @@ async def create_conversation(
         created_at=conversation.created_at,
         updated_at=conversation.updated_at,
         message_count=conversation.message_count or 0,
+        last_message=recent_messages[0] if recent_messages else None,
         recent_messages=recent_messages,
     )
 
@@ -277,6 +278,7 @@ async def list_conversations(
                 created_at=conv.created_at,
                 updated_at=conv.updated_at,
                 message_count=conv.message_count or 0,
+                last_message=recent_messages[0] if recent_messages else None,
                 recent_messages=recent_messages,
             )
         )

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -103,6 +103,7 @@ class ConversationResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     message_count: int = 0
+    last_message: LastMessageInfo | None = None
     recent_messages: list[MessageResponse] = Field(default_factory=list)
 
 


### PR DESCRIPTION
The goal is to restore the last_message field in the V1 ConversationResponse model to ensure the frontend continues to work without changes.