### PR TITLE
Capture all errors for reporting

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -78,9 +78,7 @@ impl AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, code) = self.status_and_code();
-        if status.is_server_error() {
-            sentry::capture_error(&self);
-        }
+        sentry::capture_error(&self);
         let body = ErrorBody {
             error: code,
             message: self.to_string(),


### PR DESCRIPTION
Capture errors regardless of their status code to improve error tracking and reporting.