### PR TITLE
Fix Sentry integration and remove media size limits

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -41,8 +41,6 @@ pub struct Settings {
     pub openrouter_timeout: u64,
 
     // Media limits
-    pub max_image_size_mb: u32,
-    pub max_audio_size_mb: u32,
     pub max_audio_duration_seconds: u32,
 
     // S3
@@ -159,14 +157,6 @@ impl Settings {
                 .parse()
                 .unwrap_or(30),
 
-            max_image_size_mb: env::var("MAX_IMAGE_SIZE_MB")
-                .unwrap_or("10".into())
-                .parse()
-                .unwrap_or(10),
-            max_audio_size_mb: env::var("MAX_AUDIO_SIZE_MB")
-                .unwrap_or("20".into())
-                .parse()
-                .unwrap_or(20),
             max_audio_duration_seconds: env::var("MAX_AUDIO_DURATION_SECONDS")
                 .unwrap_or("300".into())
                 .parse()
@@ -236,15 +226,5 @@ impl Settings {
             .split(',')
             .map(|s| s.trim().to_string())
             .collect()
-    }
-
-    #[inline]
-    pub fn max_image_size_bytes(&self) -> u64 {
-        self.max_image_size_mb as u64 * 1024 * 1024
-    }
-
-    #[inline]
-    pub fn max_audio_size_bytes(&self) -> u64 {
-        self.max_audio_size_mb as u64 * 1024 * 1024
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -78,6 +78,7 @@ impl AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let (status, code) = self.status_and_code();
+        tracing::error!(error = %self, code = code, "App error");
         sentry::capture_error(&self);
         let body = ErrorBody {
             error: code,

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,7 +233,11 @@ async fn main() {
         .route("/api/v1/chat/ws/inbox/{user_id}", get(websocket::ws_inbox))
         .route("/api/v1/chat/ws/docs", get(websocket::ws_docs))
         // Media
-        .route("/api/v1/media/upload", post(media::upload_media))
+        .merge(
+            Router::new()
+                .route("/api/v1/media/upload", post(media::upload_media))
+                .layer(axum::extract::DefaultBodyLimit::max(100 * 1024 * 1024)),
+        )
         // OpenAPI / Swagger UI
         .merge(routes::openapi::swagger_ui())
         // Set Sentry transaction name to route pattern after routing

--- a/src/routes/media.rs
+++ b/src/routes/media.rs
@@ -81,9 +81,9 @@ pub async fn upload_media(
 
     // Validate
     if media_type == "image" {
-        state.storage.validate_image(&file_name, size)?;
+        state.storage.validate_image(&file_name)?;
     } else {
-        state.storage.validate_audio(&file_name, size)?;
+        state.storage.validate_audio(&file_name)?;
     }
 
     // Determine content type

--- a/src/services/storage.rs
+++ b/src/services/storage.rs
@@ -15,8 +15,6 @@ pub struct StorageService {
     http_client: reqwest::Client,
     public_url_base: String,
     url_expires_seconds: u32,
-    max_image_size_bytes: u64,
-    max_audio_size_bytes: u64,
 }
 
 const IMAGE_EXTENSIONS: &[&str] = &[".jpg", ".jpeg", ".png", ".gif", ".webp"];
@@ -48,8 +46,6 @@ impl StorageService {
             http_client,
             public_url_base: settings.s3_public_url_base.clone(),
             url_expires_seconds: settings.s3_url_expires_seconds,
-            max_image_size_bytes: settings.max_image_size_bytes(),
-            max_audio_size_bytes: settings.max_audio_size_bytes(),
         })
     }
 
@@ -124,7 +120,7 @@ impl StorageService {
         url_or_key.to_string()
     }
 
-    pub fn validate_image(&self, filename: &str, size: u64) -> Result<(), AppError> {
+    pub fn validate_image(&self, filename: &str) -> Result<(), AppError> {
         let ext = file_extension(filename).to_lowercase();
         if !IMAGE_EXTENSIONS.contains(&ext.as_str()) {
             return Err(AppError::bad_request(format!(
@@ -132,27 +128,15 @@ impl StorageService {
                 IMAGE_EXTENSIONS.join(", ")
             )));
         }
-        if size > self.max_image_size_bytes {
-            return Err(AppError::bad_request(format!(
-                "Image too large. Max: {}MB",
-                self.max_image_size_bytes / (1024 * 1024)
-            )));
-        }
         Ok(())
     }
 
-    pub fn validate_audio(&self, filename: &str, size: u64) -> Result<(), AppError> {
+    pub fn validate_audio(&self, filename: &str) -> Result<(), AppError> {
         let ext = file_extension(filename).to_lowercase();
         if !AUDIO_EXTENSIONS.contains(&ext.as_str()) {
             return Err(AppError::bad_request(format!(
                 "Unsupported audio format. Allowed: {}",
                 AUDIO_EXTENSIONS.join(", ")
-            )));
-        }
-        if size > self.max_audio_size_bytes {
-            return Err(AppError::bad_request(format!(
-                "Audio too large. Max: {}MB",
-                self.max_audio_size_bytes / (1024 * 1024)
             )));
         }
         Ok(())


### PR DESCRIPTION
Enhance error reporting by integrating Sentry for issue tracking. Remove size limits for image and audio uploads, allowing files up to 100MB. Adjust validation methods accordingly.